### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/calculate_diff_evalue.jl
+++ b/src/calculate_diff_evalue.jl
@@ -9,12 +9,18 @@ end
 function calculate_diff_evalue(DQC::DQCType, cost::Vector{<:AbstractBlock}, theta, x)
     diff_evalue = ComplexF64(0.0)
     for j in 1:DQC.N
-        diff_evalue_pos = expect(Add(cost), zero_state(DQC.N) => new_circuit(
-            DQC, x, theta, j, pi/2))
-        diff_evalue_neg = expect(Add(cost), zero_state(DQC.N) => new_circuit(
-            DQC, x, theta, j, -pi/2))
+        diff_evalue_pos = expect(
+            Add(cost), zero_state(DQC.N) => new_circuit(
+                DQC, x, theta, j, pi / 2
+            )
+        )
+        diff_evalue_neg = expect(
+            Add(cost), zero_state(DQC.N) => new_circuit(
+                DQC, x, theta, j, -pi / 2
+            )
+        )
         diff_evalue += (diff_evalue_pos - diff_evalue_neg) *
-                       map_to_circuit(gradient(_x -> phi(_x, DQC.afm), x)[1], j, DQC.afm)
+            map_to_circuit(gradient(_x -> phi(_x, DQC.afm), x)[1], j, DQC.afm)
     end
     diff_evalue /= 2
     return real(diff_evalue)

--- a/src/calculate_evalue.jl
+++ b/src/calculate_evalue.jl
@@ -1,15 +1,21 @@
-function calculate_evalue(DQC::DQCType, cost::Vector{<:AbstractBlock}, u0::Float64,
-        ::Floating, theta, M_value::Real, M_initial::Real)
+function calculate_evalue(
+        DQC::DQCType, cost::Vector{<:AbstractBlock}, u0::Float64,
+        ::Floating, theta, M_value::Real, M_initial::Real
+    )
     return expect(Add(cost), zero_state(DQC.N) => new_circuit(DQC, M_value, theta)) -
-           expect(Add(cost), zero_state(DQC.N) => new_circuit(DQC, M_initial, theta)) + u0
+        expect(Add(cost), zero_state(DQC.N) => new_circuit(DQC, M_initial, theta)) + u0
 end
 
-function calculate_evalue(DQC::DQCType, cost::Vector{<:AbstractBlock},
-        ::Float64, ::Pinned, theta, M_value::Real, ::Real)
+function calculate_evalue(
+        DQC::DQCType, cost::Vector{<:AbstractBlock},
+        ::Float64, ::Pinned, theta, M_value::Real, ::Real
+    )
     return expect(Add(cost), zero_state(DQC.N) => new_circuit(DQC, M_value, theta))
 end
 
-function calculate_evalue(DQC::DQCType, cost::Vector{<:AbstractBlock}, ::Float64,
-        abh::Optimized, theta, M_value::Real, ::Real)
+function calculate_evalue(
+        DQC::DQCType, cost::Vector{<:AbstractBlock}, ::Float64,
+        abh::Optimized, theta, M_value::Real, ::Real
+    )
     return abh.fc + expect(Add(cost), zero_state(DQC.N) => new_circuit(DQC, M_value, theta))
 end

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -10,8 +10,10 @@ function calc_cost(DQC::DQCType, cost_params::CostParams)
     no_eqns = length(cost_params.lambda)
     length_range = length.(cost_params.lambda)
 
-    return [[Scale(DQC.cost[i][j], cost_params.lambda[i][j]) for j in 1:length_range[i]]
-            for i in 1:no_eqns]
+    return [
+        [Scale(DQC.cost[i][j], cost_params.lambda[i][j]) for j in 1:length_range[i]]
+            for i in 1:no_eqns
+    ]
 end
 
 function calc_cost(DQC::Vector{DQCType}, cost_params::CostParams)
@@ -21,9 +23,11 @@ function calc_cost(DQC::Vector{DQCType}, cost_params::CostParams)
     return [[Scale(DQC[i].cost[j]) for j in 1:length_range[i]] for i in 1:no_eqns]
 end
 
-function loss_diff(DQC::Vector{DQCType}, prob::AbstractODEProblem, M::AbstractVector,
+function loss_diff(
+        DQC::Vector{DQCType}, prob::AbstractODEProblem, M::AbstractVector,
         cost_params::AbstractCostParams, abh::AbstractBoundaryHandling,
-        loss::Function, theta::Vector{Vector{Float64}})
+        loss::Function, theta::Vector{Vector{Float64}}
+    )
     no_eqns = length(DQC)
     if no_eqns != length(prob.u0)
         throw("Number of encoded equations don't match number of DQCs")
@@ -31,23 +35,29 @@ function loss_diff(DQC::Vector{DQCType}, prob::AbstractODEProblem, M::AbstractVe
     cost = calc_cost(DQC, cost_params)
     Loss_diff = ComplexF64(0.0)
     for x in 1:length(M)
-        evalue = [calculate_evalue(DQC[i], cost[i], prob.u0[i], abh, theta[i], M[x], M[1])
-                  for i in 1:no_eqns]
+        evalue = [
+            calculate_evalue(DQC[i], cost[i], prob.u0[i], abh, theta[i], M[x], M[1])
+                for i in 1:no_eqns
+        ]
 
-        diff_evalue = [calculate_diff_evalue(DQC[i], cost[i], theta[i], M[x])
-                       for i in 1:no_eqns]
+        diff_evalue = [
+            calculate_diff_evalue(DQC[i], cost[i], theta[i], M[x])
+                for i in 1:no_eqns
+        ]
 
         du = ODEEncode(real.(evalue), prob.p, M[x], prob.f)
         loss_ind = [loss(diff_evalue[i], du[i]) for i in 1:no_eqns]
 
         Loss_diff += sum(loss_ind)
     end
-    return real(Loss_diff/length(M))
+    return real(Loss_diff / length(M))
 end
 
-function loss_diff(DQC::DQCType, prob::AbstractODEProblem, M::AbstractVector,
+function loss_diff(
+        DQC::DQCType, prob::AbstractODEProblem, M::AbstractVector,
         cost_params::AbstractCostParams, abh::AbstractBoundaryHandling,
-        loss::Function, theta::Vector{Float64})
+        loss::Function, theta::Vector{Float64}
+    )
     no_eqns = length(prob.u0)
     if !(DQC.cost isa Vector{<:Vector{<:AbstractBlock}})
         throw("cost functions not defined properly")
@@ -57,8 +67,10 @@ function loss_diff(DQC::DQCType, prob::AbstractODEProblem, M::AbstractVector,
     Loss_diff = ComplexF64(0.0)
     cost = calc_cost(DQC, cost_params)
     for x in 1:length(M)
-        evalue = [calculate_evalue(DQC, cost[i], prob.u0[i], abh, theta, M[x], M[1])
-                  for i in 1:no_eqns]
+        evalue = [
+            calculate_evalue(DQC, cost[i], prob.u0[i], abh, theta, M[x], M[1])
+                for i in 1:no_eqns
+        ]
 
         diff_evalue = [calculate_diff_evalue(DQC, cost[i], theta, M[x]) for i in 1:no_eqns]
 
@@ -67,54 +79,69 @@ function loss_diff(DQC::DQCType, prob::AbstractODEProblem, M::AbstractVector,
 
         Loss_diff += sum(loss_ind)
     end
-    return real(Loss_diff/length(M))
+    return real(Loss_diff / length(M))
 end
 
-function loss_reg(::Union{DQCType, Vector{DQCType}}, ::Vector{Float64}, ::NoRegularisation,
-        ::AbstractCostParams, ::AbstractBoundaryHandling, ::Function, ::Any)
+function loss_reg(
+        ::Union{DQCType, Vector{DQCType}}, ::Vector{Float64}, ::NoRegularisation,
+        ::AbstractCostParams, ::AbstractBoundaryHandling, ::Function, ::Any
+    )
     return 0.0
 end
 
-function loss_reg(DQC::DQCType, u0::Vector{Float64}, rp::RegularisationParams,
+function loss_reg(
+        DQC::DQCType, u0::Vector{Float64}, rp::RegularisationParams,
         cost_params::AbstractCostParams, abh::AbstractBoundaryHandling,
-        loss::Function, theta::Vector{Float64})
+        loss::Function, theta::Vector{Float64}
+    )
     no_eqns = length(u0)
     cost = calc_cost(DQC, cost_params)
     Loss_reg = ComplexF64(0.0)
     for x in 1:length(rp.M_reg)
-        evalue = [calculate_evalue(
-                      DQC, cost[i], u0[i], abh, theta, rp.M_reg[x], rp.M_reg[1])
-                  for i in 1:no_eqns]
+        evalue = [
+            calculate_evalue(
+                    DQC, cost[i], u0[i], abh, theta, rp.M_reg[x], rp.M_reg[1]
+                )
+                for i in 1:no_eqns
+        ]
         loss_ind = [loss(evalue[i], rp.u_reg[i][x]) for i in 1:no_eqns]
         Loss_reg += sum(loss_ind)
     end
     return real(Loss_reg)
 end
 
-function loss_reg(DQC::Vector{DQCType}, u0::Vector{Float64}, rp::RegularisationParams,
+function loss_reg(
+        DQC::Vector{DQCType}, u0::Vector{Float64}, rp::RegularisationParams,
         cost_params::AbstractCostParams, abh::AbstractBoundaryHandling,
-        loss::Function, theta::Vector{Vector{Float64}})
+        loss::Function, theta::Vector{Vector{Float64}}
+    )
     no_eqns = length(DQC)
     cost = calc_cost(DQC, cost_params)
     Loss_reg = ComplexF64(0.0)
     for x in 1:length(rp.M_reg)
-        evalue = [calculate_evalue(
-                      DQC[i], cost[i], u0[i], abh, theta[i], rp.M_reg[x], rp.M_reg[1])
-                  for i in 1:no_eqns]
+        evalue = [
+            calculate_evalue(
+                    DQC[i], cost[i], u0[i], abh, theta[i], rp.M_reg[x], rp.M_reg[1]
+                )
+                for i in 1:no_eqns
+        ]
         loss_ind = [loss(evalue[i], rp.u_reg[i][x]) for i in 1:no_eqns]
         Loss_reg += sum(loss_ind)
     end
     return real(Loss_reg)
 end
 
-function loss_bound(::Union{DQCType, Vector{DQCType}}, ::Real, ::Vector{Float64},
-        ::AbstractCostParams, ::Union{Floating, Optimized}, ::Function, ::Any)
+function loss_bound(
+        ::Union{DQCType, Vector{DQCType}}, ::Real, ::Vector{Float64},
+        ::AbstractCostParams, ::Union{Floating, Optimized}, ::Function, ::Any
+    )
     return 0.0
 end
 
 function loss_bound(
         DQC::DQCType, M::Real, u0::Vector{Float64}, cost_params::AbstractCostParams,
-        abh::Pinned, loss::Function, theta::Vector{Float64})
+        abh::Pinned, loss::Function, theta::Vector{Float64}
+    )
     no_eqns = length(u0)
     cost = calc_cost(DQC, cost_params)
     evalue = [calculate_evalue(DQC, cost[i], u0[i], abh, theta, M, M) for i in 1:no_eqns]
@@ -124,20 +151,28 @@ end
 
 function loss_bound(
         DQC::Vector{DQCType}, M::Real, u0::Vector{Float64}, cost_params::AbstractCostParams,
-        abh::Pinned, loss::Function, theta::Vector{Vector{Float64}})
+        abh::Pinned, loss::Function, theta::Vector{Vector{Float64}}
+    )
     no_eqns = length(u0)
     cost = calc_cost(DQC, cost_params)
-    evalue = [calculate_evalue(DQC[i], cost[i], u0[i], abh, theta[i], M, M)
-              for i in 1:no_eqns]
+    evalue = [
+        calculate_evalue(DQC[i], cost[i], u0[i], abh, theta[i], M, M)
+            for i in 1:no_eqns
+    ]
     loss_ind = abh.eta * sum([loss(evalue[i], u0[i]) for i in 1:no_eqns])
     return real(loss_ind)
 end
 
-function loss(DQC::Union{DQCType, Vector{DQCType}}, prob::AbstractODEProblem,
-        config::DQCConfig, M::AbstractVector, theta)
+function loss(
+        DQC::Union{DQCType, Vector{DQCType}}, prob::AbstractODEProblem,
+        config::DQCConfig, M::AbstractVector, theta
+    )
     return loss_diff(DQC, prob, M, config.cost_params, config.abh, config.loss, theta) +
-           loss_reg(DQC, prob.u0, config.reg, config.cost_params,
-               config.abh, config.loss, theta) +
-           loss_bound(
-               DQC, M[1], prob.u0, config.cost_params, config.abh, config.loss, theta)
+        loss_reg(
+        DQC, prob.u0, config.reg, config.cost_params,
+        config.abh, config.loss, theta
+    ) +
+        loss_bound(
+        DQC, M[1], prob.u0, config.cost_params, config.abh, config.loss, theta
+    )
 end

--- a/src/new_circuit.jl
+++ b/src/new_circuit.jl
@@ -7,7 +7,7 @@ function load(x, N, mapping::ChebyshevSparse)
 end
 
 function load(x, N, mapping::ChebyshevTower)
-    return [i*phi(x, mapping) for i in 1:N]
+    return [i * phi(x, mapping) for i in 1:N]
 end
 
 function new_circuit(DQC::DQCType, x, theta, n = 1, v = 0)

--- a/src/phi.jl
+++ b/src/phi.jl
@@ -3,5 +3,5 @@ function phi(x, ::Product)
 end
 
 function phi(x, mapping::Union{ChebyshevSparse, ChebyshevTower})
-    return mapping.pc*acos(x)
+    return mapping.pc * acos(x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using QuantumNLDiffEq
 using Test
 using Yao: dispatch, EasyBuild, put, Z, chain, Ry, parameters, zero_state, expect,
-           parameters, Add
+    parameters, Add
 using Zygote: gradient
 using DifferentialEquations
 using Optimisers: Adam
@@ -10,7 +10,7 @@ M = range(0; stop = 0.9, length = 20)
 @testset "Tests for damped oscillation equations" begin
     function f(u, p, t)
         λ, κ = p
-        return -1*λ*u*(κ + tan(λ*t))
+        return -1 * λ * u * (κ + tan(λ * t))
     end
     prob = ODEProblem(f, [1.0], (0.0, 0.9), [8.0, 0.1])
     function loss_func(a, b)
@@ -18,15 +18,24 @@ M = range(0; stop = 0.9, length = 20)
     end
 
     @testset "Boundary Handling Tests" begin
-        DQC = [QuantumNLDiffEq.DQCType(afm = QuantumNLDiffEq.ChebyshevSparse(2),
-            fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-            cost = [Add([put(6, i=>Z) for i in 1:6])],
-            var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)]
+        DQC = [
+            QuantumNLDiffEq.DQCType(
+                afm = QuantumNLDiffEq.ChebyshevSparse(2),
+                fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                cost = [Add([put(6, i => Z) for i in 1:6])],
+                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+            ),
+        ]
         config(boundary) = DQCConfig(abh = boundary, loss = loss_func)
-        evalue(M,
-            conf) = [QuantumNLDiffEq.calculate_evalue(
-                         DQC[1], DQC[1].cost, prob.u0[1], conf.abh, params[1], M[x], M[1])
-                     for x in 1:length(M)]
+        evalue(
+            M,
+            conf
+        ) = [
+            QuantumNLDiffEq.calculate_evalue(
+                    DQC[1], DQC[1].cost, prob.u0[1], conf.abh, params[1], M[x], M[1]
+                )
+                for x in 1:length(M)
+        ]
 
         @testset "Test for Pinned Boundary Handling" begin
             conf = config(QuantumNLDiffEq.Pinned(2.5))
@@ -51,16 +60,24 @@ M = range(0; stop = 0.9, length = 20)
     end
 
     @testset "Mapping Tests" begin
-        DQ(mapping) = [QuantumNLDiffEq.DQCType(
-            afm = mapping, fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-            cost = [Add([put(6, i=>Z) for i in 1:6])],
-            var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)]
+        DQ(mapping) = [
+            QuantumNLDiffEq.DQCType(
+                afm = mapping, fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                cost = [Add([put(6, i => Z) for i in 1:6])],
+                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+            ),
+        ]
         config = DQCConfig(abh = QuantumNLDiffEq.Floating(), loss = loss_func)
-        evalue(M,
-            mapping) = [QuantumNLDiffEq.calculate_evalue(
-                            DQC(mapping), DQC(mapping)[1].cost,
-                            prob.u0[1], conf.abh, params[1], M[x], M[1])
-                        for x in 1:length(M)]
+        evalue(
+            M,
+            mapping
+        ) = [
+            QuantumNLDiffEq.calculate_evalue(
+                    DQC(mapping), DQC(mapping)[1].cost,
+                    prob.u0[1], conf.abh, params[1], M[x], M[1]
+                )
+                for x in 1:length(M)
+        ]
 
         @testset "Test for Product Feature Mapping" begin
             input = DQ(QuantumNLDiffEq.Product())
@@ -70,10 +87,12 @@ M = range(0; stop = 0.9, length = 20)
         end
 
         @testset "Test for Chebyshev Sparse Mapping" begin
-            input = QuantumNLDiffEq.DQCType(afm = QuantumNLDiffEq.ChebyshevSparse(2),
-                fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-                cost = [[Add([put(6, i=>Z) for i in 1:6])]],
-                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)
+            input = QuantumNLDiffEq.DQCType(
+                afm = QuantumNLDiffEq.ChebyshevSparse(2),
+                fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                cost = [[Add([put(6, i => Z) for i in 1:6])]],
+                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+            )
             params = parameters(input.var)
             QuantumNLDiffEq.train!(input, prob, config, M, params)
             @test QuantumNLDiffEq.loss(input, prob, config, M, params) < 0.5
@@ -89,23 +108,36 @@ M = range(0; stop = 0.9, length = 20)
 
     @testset "Regularization Tests" begin
         @testset "Singular Encoding" begin
-            DQC = QuantumNLDiffEq.DQCType(afm = QuantumNLDiffEq.ChebyshevSparse(2),
-                fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-                cost = [[Add([put(6, i=>Z) for i in 1:6])]],
-                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)
+            DQC = QuantumNLDiffEq.DQCType(
+                afm = QuantumNLDiffEq.ChebyshevSparse(2),
+                fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                cost = [[Add([put(6, i => Z) for i in 1:6])]],
+                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+            )
             config = DQCConfig(
                 reg = QuantumNLDiffEq.RegularisationParams(
-                    [[1.0, 0.04724630684751344, -0.7340180576454999,
-                        -0.10424985483835963, 0.5322086377394599]],
-                    [0.0, 0.18947368421052632, 0.37894736842105264,
-                        0.5684210526315789, 0.7578947368421053],
-                    0.0),
+                    [
+                        [
+                            1.0, 0.04724630684751344, -0.7340180576454999,
+                            -0.10424985483835963, 0.5322086377394599,
+                        ],
+                    ],
+                    [
+                        0.0, 0.18947368421052632, 0.37894736842105264,
+                        0.5684210526315789, 0.7578947368421053,
+                    ],
+                    0.0
+                ),
                 abh = QuantumNLDiffEq.Floating(),
-                loss = loss_func)
-            evalue(M) = [QuantumNLDiffEq.calculate_evalue(
-                             QuantumNLDiffEqChebyshevSparse(2), DQC(mapping)[1].cost,
-                             prob.u0[1], config.abh, params[1], M[x], M[1])
-                         for x in 1:length(M)]
+                loss = loss_func
+            )
+            evalue(M) = [
+                QuantumNLDiffEq.calculate_evalue(
+                        QuantumNLDiffEqChebyshevSparse(2), DQC(mapping)[1].cost,
+                        prob.u0[1], config.abh, params[1], M[x], M[1]
+                    )
+                    for x in 1:length(M)
+            ]
             params = parameters(DQC.var)
             QuantumNLDiffEq.tr_custom!(DQC, prob, config, M, params)
             @show loss = QuantumNLDiffEq.loss(DQC, prob, config, M, params)
@@ -113,23 +145,38 @@ M = range(0; stop = 0.9, length = 20)
         end
 
         @testset "Multiple Encoding" begin
-            DQC = [QuantumNLDiffEq.DQCType(afm = QuantumNLDiffEq.ChebyshevSparse(2),
-                fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-                cost = [Add([put(6, i=>Z) for i in 1:6])],
-                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)]
+            DQC = [
+                QuantumNLDiffEq.DQCType(
+                    afm = QuantumNLDiffEq.ChebyshevSparse(2),
+                    fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                    cost = [Add([put(6, i => Z) for i in 1:6])],
+                    var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+                ),
+            ]
             config = DQCConfig(
                 reg = QuantumNLDiffEq.RegularisationParams(
-                    [[1.0, 0.04724630684751344, -0.7340180576454999,
-                        -0.10424985483835963, 0.5322086377394599]],
-                    [0.0, 0.18947368421052632, 0.37894736842105264,
-                        0.5684210526315789, 0.7578947368421053],
-                    0.0),
+                    [
+                        [
+                            1.0, 0.04724630684751344, -0.7340180576454999,
+                            -0.10424985483835963, 0.5322086377394599,
+                        ],
+                    ],
+                    [
+                        0.0, 0.18947368421052632, 0.37894736842105264,
+                        0.5684210526315789, 0.7578947368421053,
+                    ],
+                    0.0
+                ),
                 abh = QuantumNLDiffEq.Floating(),
-                loss = loss_func)
-            evalue(M) = [QuantumNLDiffEq.calculate_evalue(
-                             QuantumNLDiffEqChebyshevSparse(2), DQC(mapping)[1].cost,
-                             prob.u0[1], config.abh, params[1], M[x], M[1])
-                         for x in 1:length(M)]
+                loss = loss_func
+            )
+            evalue(M) = [
+                QuantumNLDiffEq.calculate_evalue(
+                        QuantumNLDiffEqChebyshevSparse(2), DQC(mapping)[1].cost,
+                        prob.u0[1], config.abh, params[1], M[x], M[1]
+                    )
+                    for x in 1:length(M)
+            ]
             params = [parameters(DQC[1].var)]
             QuantumNLDiffEq.tr_custom!(DQC, prob, config, M, params)
             loss = QuantumNLDiffEq.loss(DQC, prob, config, M, params)
@@ -141,7 +188,7 @@ end
 @testset "Encoding multifunction system" begin
     function f(u, p, t)
         λ1, λ2 = p
-        return [λ1*u[2] + λ2*u[1], -λ1*u[1] - λ2*u[2]]
+        return [λ1 * u[2] + λ2 * u[1], -λ1 * u[1] - λ2 * u[2]]
     end
     prob = ODEProblem(f, [0.5, 0.0], (0.0, 0.9), [5.0, 3.0])
     function loss_func(a, b)
@@ -149,13 +196,19 @@ end
     end
     config = DQCConfig(abh = QuantumNLDiffEq.Floating(), loss = loss_func)
     DQC = repeat(
-        [QuantumNLDiffEq.DQCType(afm = QuantumNLDiffEq.ChebyshevTower(2),
-            fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-            cost = [sum([put(6, i=>Z) for i in 1:6])],
-            var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6)],
-        2)
+        [
+            QuantumNLDiffEq.DQCType(
+                afm = QuantumNLDiffEq.ChebyshevTower(2),
+                fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+                cost = [sum([put(6, i => Z) for i in 1:6])],
+                var = dispatch(EasyBuild.variational_circuit(6, 5), :random), N = 6
+            ),
+        ],
+        2
+    )
     params = [parameters(DQC[1].var), parameters(DQC[2].var)]
     QuantumNLDiffEq.train!(
-        DQC, prob, config, M, params; optimizer = Adam(0.02), steps = 400)
+        DQC, prob, config, M, params; optimizer = Adam(0.02), steps = 400
+    )
     @test QuantumNLDiffEq.loss(DQC, prob, config, M, params) < 0.05
 end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)