### PR TITLE
Downgrade CI: fix branch trigger + raise Yao floor to 0.9.2

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,12 +2,12 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumNLDiffEq"
 uuid = "5411918f-e61c-4722-a33e-8517a813f4bd"
 authors = ["SciML"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -21,7 +21,7 @@ SafeTestsets = "0.1, 1"
 SciMLBase = "1, 2, 3.1"
 SciMLTesting = "1"
 Test = "1"
-Yao = "0.8, 0.9"
+Yao = "0.9.2"
 Zygote = "0.6, 0.7, 0.8"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary

Makes the **Downgrade** lane both *run* and *pass*. Two independent fixes.

### 1. Downgrade.yml never triggered on the default branch
`Downgrade.yml`'s `pull_request`/`push` triggers were keyed to `master`, but this repo's default branch is `main` (as are `Tests.yml` and `FormatCheck.yml`). So the centralized SciML downgrade workflow was never invoked — the audit's "Downgrade never ran" observation. Retargeted both triggers to `main`.

### 2. Genuine downgrade floor failure (LuxurySparse precompile on Julia 1.10)
At the LTS floor the resolver picks **Yao 0.8.0**, which drags in **LuxurySparse 0.6.13**. That version (and 0.7.0) redefines `convert(::Type{Diagonal}, ::AbstractMatrix)` over the `LinearAlgebra` method. On Julia 1.10 method overwriting during module precompilation is a **hard error**, so the whole stack — LuxurySparse → YaoArrayRegister → YaoBlocks → YaoSym → Yao → QuantumNLDiffEq — fails to precompile and the downgrade job errors at `julia-buildpkg`.

`LuxurySparse >= 0.7.1` precompiles cleanly on 1.10, but **no Yao version pins LuxurySparse `>= 0.7.1`**: Yao 0.8.3–0.9.1 all declare LuxurySparse `"0.7"` (which still admits the broken 0.7.0), and only **Yao `>= 0.9.2`** requires LuxurySparse `"0.8"`. So the minimal correct fix is to raise the Yao floor:

```
-Yao = "0.8, 0.9"
+Yao = "0.9.2"
```

The happy-path CI already runs **Yao 0.9.3 / LuxurySparse 0.8.1**, so this only drops the already-unbuildable `0.8.x` floor line; nothing in the tested range changes.

## Validation (local, Julia 1.10, released `julia-downgrade-compat` v2.6.1)

- **Before:** downgrade resolves Yao 0.8.0 + LuxurySparse 0.6.13 → 6 dependencies fail to precompile with `ERROR: Method overwriting is not permitted during Module precompilation` (`convert(Diagonal, …)`).
- **After (`Yao = "0.9.2"`):** merged test env resolves LuxurySparse **0.8.1** / Yao **0.9.2**, precompiles with **zero** method-overwrite errors, `using QuantumNLDiffEq` loads, and the Core test group runs at the floor.

**QA is already green** and unaffected: `Quality Assurance 18/18` on Julia 1.12.6 against released SciMLTesting 1.8.0 (JET 0.11.5, Aqua 0.8.16). The prior QA(1) red was a *self-hosted runner lost communication* infra failure (logs expired), not a code failure — reproduced clean locally.

---
Draft: please **ignore until reviewed by @ChrisRackauckas**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)