### PR TITLE
Release prep: bump to 1.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumNLDiffEq"
 uuid = "5411918f-e61c-4722-a33e-8517a813f4bd"
 authors = ["SciML"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Version-bump-only release PR. Raises compat floors on ChainRulesCore/Optimisers/Zygote (narrows resolvable versions only, does not affect users already on newer versions) and swaps DifferentialEquations for SciMLBase in test-only deps.