### PR TITLE
Document rendered public API

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+QuantumNLDiffEq = "5411918f-e61c-4722-a33e-8517a813f4bd"
+
+[compat]
+Documenter = "1"
+QuantumNLDiffEq = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+using Pkg
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+
+using Documenter
+using QuantumNLDiffEq
+
+makedocs(;
+    modules = [QuantumNLDiffEq],
+    sitename = "QuantumNLDiffEq.jl",
+    pages = [
+        "Home" => "index.md",
+    ],
+    clean = true,
+    doctest = false,
+    checkdocs = :exports,
+)
+
+deploydocs(; repo = "github.com/SciML/QuantumNLDiffEq.jl.git", push_preview = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,12 @@
+# QuantumNLDiffEq.jl
+
+QuantumNLDiffEq.jl solves nonlinear differential equations with Differential Quantum Circuits.
+
+## Public API
+
+```@docs
+DQCType
+DQCConfig
+loss
+train!
+```

--- a/src/QuantumNLDiffEq.jl
+++ b/src/QuantumNLDiffEq.jl
@@ -54,17 +54,39 @@ struct CostParams <: AbstractCostParams
 end
 
 """
-    DQCType
+    DQCType(; afm, fm, cost, var, N, evol = igate(N))
 
-Differential Quantum Circuit type that encodes the structure of a quantum circuit for solving differential equations.
+Describe a Differential Quantum Circuit (DQC) used by [`loss`](@ref) and
+[`train!`](@ref).
+
+Use one `DQCType` for a scalar differential equation, or a vector of
+`DQCType`s for a system where each state component is represented by its own
+circuit.
 
 # Fields
-- `afm::AbstractFeatureMap`: Ansatz feature mapping (e.g., `ChebyshevSparse`, `ChebyshevTower`, `Product`)
-- `fm::AbstractBlock`: Feature map quantum circuit
-- `cost::Union{Vector{<:AbstractBlock}, Vector{<:Vector{<:AbstractBlock}}}`: Cost function observables
-- `var::AbstractBlock`: Variational quantum circuit
-- `N::Int64`: Number of qubits
-- `evol::Union{TimeEvolution, IdentityGate}`: Time evolution operator (default: identity gate)
+
+- `afm`: Ansatz feature map, such as `QuantumNLDiffEq.ChebyshevSparse`.
+- `fm`: Feature-map quantum circuit.
+- `cost`: Cost observable or observables. For a single circuit encoding
+  multiple equations, pass a vector of observable vectors.
+- `var`: Variational quantum circuit.
+- `N`: Number of qubits.
+- `evol`: Optional time-evolution block. Defaults to the identity gate on `N`
+  qubits.
+
+# Examples
+
+```julia
+using QuantumNLDiffEq, Yao
+
+DQC = DQCType(
+    afm = QuantumNLDiffEq.ChebyshevSparse(2),
+    fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+    cost = [Add([put(6, i => Z) for i in 1:6])],
+    var = dispatch(EasyBuild.variational_circuit(6, 5), :random),
+    N = 6,
+)
+```
 """
 Base.@kwdef mutable struct DQCType
     afm::AbstractFeatureMap
@@ -76,15 +98,33 @@ Base.@kwdef mutable struct DQCType
 end
 
 """
-    DQCConfig
+    DQCConfig(; reg = NoRegularisation(), cost_params = NoCostParams(), abh, loss)
 
-Configuration for Differential Quantum Circuit training and evaluation.
+Configure the loss terms and boundary handling used by [`loss`](@ref) and
+[`train!`](@ref).
+
+`DQCConfig` keeps the training objective separate from the circuit definition
+in [`DQCType`](@ref). The `loss` field should be a scalar penalty function that
+compares a predicted value with a target value.
 
 # Fields
-- `reg::AbstractRegularisationParams`: Regularization parameters (default: `NoRegularisation()`)
-- `cost_params::AbstractCostParams`: Cost function parameters (default: `NoCostParams()`)
-- `abh::AbstractBoundaryHandling`: Boundary handling method (`Floating`, `Pinned`, or `Optimized`)
-- `loss::Function`: Loss function for training
+
+- `reg`: Regularization data for matching known solution values. Defaults to no
+  regularization.
+- `cost_params`: Weights for cost observables. Defaults to unweighted costs.
+- `abh`: Boundary handling strategy, such as `QuantumNLDiffEq.Floating()`.
+- `loss`: Function called as `loss(predicted, target)` for each penalty term.
+
+# Examples
+
+```julia
+using QuantumNLDiffEq
+
+config = DQCConfig(
+    abh = QuantumNLDiffEq.Floating(),
+    loss = (predicted, target) -> abs2(predicted - target),
+)
+```
 """
 Base.@kwdef mutable struct DQCConfig
     reg::AbstractRegularisationParams = NoRegularisation()
@@ -124,35 +164,47 @@ function apply_update!(opt_state, theta::Vector{Vector{Float64}}, grads)
 end
 
 """
-    train!(DQC, prob, config, M, theta; optimizer=Adam(0.075), steps=300)
+    train!(DQC, prob, config, M, theta; optimizer = Optimisers.Adam(0.075), steps = 300)
 
-Train a Differential Quantum Circuit (DQC) to solve an ODE problem.
+Train one or more Differential Quantum Circuits against an ODE problem.
+
+`train!` minimizes [`loss`](@ref) over the mesh points `M`, updates `theta` in
+place, and dispatches the updated parameters back into the variational circuit.
+It returns `nothing`.
 
 # Arguments
-- `DQC::Union{DQCType, Vector{DQCType}}`: Single DQC or vector of DQCs for multi-equation systems
-- `prob::AbstractODEProblem`: SciMLBase-compatible ODE problem
-- `config::DQCConfig`: Configuration for training (boundary handling, loss function, etc.)
-- `M::AbstractVector`: Mesh points for training
-- `theta`: Initial parameters for the variational circuit(s)
+
+- `DQC`: A [`DQCType`](@ref), or a vector of `DQCType`s for multi-equation
+  systems.
+- `prob`: SciMLBase-compatible ODE problem.
+- `config`: Training configuration, including boundary handling and the scalar
+  penalty function.
+- `M`: Mesh points used to evaluate the training objective.
+- `theta`: Parameters for the variational circuit or circuits. The shape should
+  match `DQC`: one parameter vector for a single circuit, or one vector per
+  circuit.
 
 # Keyword Arguments
-- `optimizer=Adam(0.075)`: Flux optimizer for gradient descent
-- `steps=300`: Number of training iterations
 
-# Example
+- `optimizer`: Optimisers.jl optimizer used for gradient updates.
+- `steps`: Number of training iterations.
+
+# Examples
+
 ```julia
 using SciMLBase, Yao, QuantumNLDiffEq
 
-prob = ODEProblem((u,p,t) -> -1*p[1]*u*(p[2] + tan(p[1]*t)), [1.0], (0.0, 0.9), [8.0, 0.1])
+prob = ODEProblem((u, p, t) -> -p[1] * u * (p[2] + tan(p[1] * t)),
+    [1.0], (0.0, 0.9), [8.0, 0.1])
 DQC = [QuantumNLDiffEq.DQCType(
     afm = QuantumNLDiffEq.ChebyshevSparse(2),
-    fm = chain(6, [put(i=>Ry(0)) for i in 1:6]),
-    cost = [Add([put(6, i=>Z) for i in 1:6])],
-    var = dispatch(EasyBuild.variational_circuit(6,5), :random),
-    N = 6
+    fm = chain(6, [put(i => Ry(0)) for i in 1:6]),
+    cost = [Add([put(6, i => Z) for i in 1:6])],
+    var = dispatch(EasyBuild.variational_circuit(6, 5), :random),
+    N = 6,
 )]
-config = DQCConfig(abh = QuantumNLDiffEq.Floating(), loss = (a,b) -> (a-b)^2)
-M = range(0, stop=0.9, length=20)
+config = DQCConfig(abh = QuantumNLDiffEq.Floating(), loss = (a, b) -> abs2(a - b))
+M = range(0, stop = 0.9, length = 20)
 params = [Yao.parameters(DQC[1].var)]
 
 QuantumNLDiffEq.train!(DQC, prob, config, M, params)

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -166,22 +166,30 @@ end
 """
     loss(DQC, prob, config, M, theta)
 
-Calculate the total loss for training a DQC to solve an ODE problem.
+Evaluate the training objective for one or more Differential Quantum Circuits.
 
-The total loss is composed of three components:
-- Differential loss: How well the circuit's derivative matches the ODE
-- Regularization loss: Penalty term for deviation from known solution points (if configured)
-- Boundary loss: Penalty for boundary condition violations (for Pinned boundary handling)
+The total objective combines the differential-equation residual, the optional
+regularization penalty configured by `config.reg`, and the boundary penalty
+configured by `config.abh`.
 
 # Arguments
-- `DQC::Union{DQCType, Vector{DQCType}}`: Single DQC or vector of DQCs
-- `prob::AbstractODEProblem`: ODE problem
-- `config::DQCConfig`: Configuration including loss function and boundary handling
-- `M::AbstractVector`: Mesh points for evaluation
-- `theta`: Current parameters of the variational circuit(s)
+
+- `DQC`: A [`DQCType`](@ref), or a vector of `DQCType`s for systems.
+- `prob`: SciMLBase-compatible ODE problem.
+- `config`: [`DQCConfig`](@ref) containing the scalar penalty function and
+  boundary/regularization settings.
+- `M`: Mesh points where the objective is evaluated.
+- `theta`: Current variational-circuit parameters.
 
 # Returns
-- `Real`: Total loss value
+
+Returns the real-valued objective used by [`train!`](@ref).
+
+# Examples
+
+```julia
+objective = loss(DQC, prob, config, M, theta)
+```
 """
 function loss(
         DQC::Union{DQCType, Vector{DQCType}}, prob::AbstractODEProblem,

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-QuantumNLDiffEq = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,7 @@ using JET
 
 run_qa(
     QuantumNLDiffEq;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         # ForwardDiff.jacobian is not declared public in ForwardDiff yet. Drop this once


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Add a minimal Documenter manual that renders the exported QuantumNLDiffEq public API.
- Expand source docstrings for `DQCType`, `DQCConfig`, `loss`, and `train!` with signatures, arguments, returns, and examples.
- Enable SciMLTesting rendered public-docs QA and remove the redundant QA `[sources]` path override.

## Validation

- `git diff --check`
- `julia +1.10 -e 'using Runic; exit(Runic.main(["--check", "."]))'`
- `GROUP=QA timeout 3600 julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` -> `QA/qa.jl | 18/18`, `QuantumNLDiffEq tests passed`
- `timeout 3600 julia +1.10 --project=docs docs/make.jl` -> completed; only local Documenter deployment warning
- `env -u GROUP timeout 3600 julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` -> timed out after 3600s while still in the long core training test (`test/damped_oscillation_tests.jl`); no assertion failure was observed before timeout
