### PR TITLE
Bump QuantumNLDiffEq to v1.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumNLDiffEq"
 uuid = "5411918f-e61c-4722-a33e-8517a813f4bd"
 authors = ["SciML"]
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Bumps `QuantumNLDiffEq` **v1.1.3 → v1.1.4** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Document rendered public API (#70) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)