### PR TITLE
Keep Zygote AD out of the precompile workload

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,18 @@
 using PrecompileTools: @compile_workload, @setup_workload
 
+# NOTE: the workload deliberately covers only the forward, non-differentiated
+# code path (`phi`, `load`, `new_circuit`, `calculate_evalue`).
+#
+# `loss` and `train!` must NOT be called here. Both run `Zygote.gradient` on the
+# closure `_x -> phi(_x, DQC.afm)` inside `calculate_diff_evalue`. `DQCType.afm`
+# is abstractly typed (`::AbstractFeatureMap`), so that closure - and hence the
+# `Zygote.Pullback` type whose call operator is `@generated` - is identical for
+# every feature map. Running it inside `@compile_workload` bakes the adjoint
+# generated for the workload's feature map into the package image, and Julia then
+# reuses it for every other feature map, which errors with e.g.
+# `BoundsError: attempt to access Tuple{Nothing, Float64} at index [3]` or
+# `MethodError: no method matching *(::Float64, ::Nothing)`.
+# See test/precompile_workload.jl for the regression test.
 function _precompile_workload()
     nqubits = 2
     feature_map = ChebyshevSparse(2)
@@ -26,9 +39,10 @@ function _precompile_workload()
 
     phi(0.25, feature_map)
     load(0.25, nqubits, feature_map)
+    new_circuit(dqc, mesh[2], theta)
     calculate_evalue(dqc, dqc.cost[1], problem.u0[1], config.abh, theta, mesh[2], mesh[1])
-    loss(dqc, problem, config, mesh, theta)
-    train!(dqc, problem, config, mesh, theta; steps = 1)
+    calculate_evalue(dqc, dqc.cost[1], problem.u0[1], Floating(), theta, mesh[2], mesh[1])
+    ODEEncode([problem.u0[1]], problem.p, mesh[2], problem.f)
     return nothing
 end
 

--- a/test/precompile_workload.jl
+++ b/test/precompile_workload.jl
@@ -1,6 +1,53 @@
 using QuantumNLDiffEq
+using Yao: Add, EasyBuild, Ry, Z, chain, dispatch, nparameters, parameters, put
+using SciMLBase: ODEProblem
 using Test
 
 @testset "Precompile workload" begin
     @test isnothing(QuantumNLDiffEq._precompile_workload())
+end
+
+# Regression test for the precompile workload corrupting Zygote's cached
+# adjoints. `DQCType.afm` is abstractly typed, so the closure differentiated
+# inside `calculate_diff_evalue` has the same type for every feature map. When
+# the precompile workload ran `loss`/`train!`, the `@generated` Zygote pullback
+# compiled for the workload's feature map was baked into the package image and
+# reused for all other feature maps, so `loss` and `train!` errored for every
+# feature map except the one exercised by the workload.
+@testset "Differentiation works for every feature map" begin
+    nqubits = 2
+    mesh = range(0; stop = 0.3, length = 3)
+    problem = ODEProblem((u, p, t) -> -p[1] .* u, [1.0], (0.0, 0.3), [0.5])
+    config = DQCConfig(
+        abh = QuantumNLDiffEq.Floating(), loss = (a, b) -> (a - b)^2
+    )
+
+    function build(mapping)
+        template = EasyBuild.variational_circuit(nqubits, 1)
+        return [
+            QuantumNLDiffEq.DQCType(
+                afm = mapping,
+                fm = chain(nqubits, [put(i => Ry(0.0)) for i in 1:nqubits]),
+                cost = [Add([put(nqubits, i => Z) for i in 1:nqubits])],
+                var = dispatch(template, zeros(nparameters(template))),
+                N = nqubits
+            ),
+        ]
+    end
+
+    mappings = (
+        "Product" => QuantumNLDiffEq.Product(),
+        "ChebyshevSparse" => QuantumNLDiffEq.ChebyshevSparse(2),
+        "ChebyshevTower" => QuantumNLDiffEq.ChebyshevTower(2),
+    )
+
+    for (name, mapping) in mappings
+        @testset "$name" begin
+            dqc = build(mapping)
+            params = [parameters(dqc[1].var)]
+            @test isfinite(QuantumNLDiffEq.loss(dqc, problem, config, mesh, params))
+            QuantumNLDiffEq.train!(dqc, problem, config, mesh, params; steps = 1)
+            @test isfinite(QuantumNLDiffEq.loss(dqc, problem, config, mesh, params))
+        end
+    end
 end


### PR DESCRIPTION
## Failing lanes

On master (`e2fdf20`, "Add PrecompileTools workload (#75)") these two checks fail, and were green at the last released commit `c2a2c74` (v1.2.0):

- `tests / Core (julia 1, ubuntu-latest) / Tests - Core (Julia 1)`
- `tests / Core (julia pre, ubuntu-latest) / Tests - Core (Julia pre)`

Both fail in `test/damped_oscillation_tests.jl` → `Mapping Tests`, in exactly two of the three subtests:

```
Test for Product Feature Mapping: Error During Test at test/damped_oscillation_tests.jl:98
  Got exception outside of a @test
  MethodError: no method matching *(::Float64, ::Nothing)          # Julia 1.12.7
  BoundsError: attempt to access Tuple{Nothing, Float64} at index [3]   # Julia 1.13.0-rc3

Test for Chebyshev Tower Mapping: Error During Test at test/damped_oscillation_tests.jl:120
  MethodError: no method matching *(::Nothing, ::Int64)            # Julia 1.12.7
  BoundsError: attempt to access Tuple{Nothing, Float64} at index [3]   # Julia 1.13.0-rc3
```

with the innermost frames in `src/calculate_diff_evalue.jl` under `Zygote._pullback`. `Test for Chebyshev Sparse Mapping` passes, and `Core (julia lts)` passes entirely (the bug is Julia-version dependent).

## Root cause

`calculate_diff_evalue` calls a *nested* Zygote gradient:

```julia
map_to_circuit(gradient(_x -> phi(_x, DQC.afm), x)[1], j, DQC.afm)
```

`train!` differentiates `loss` → `loss_diff` → `calculate_diff_evalue`, so that inner `gradient` is itself differentiated (second-order Zygote). Zygote's pullback call operator is `@generated` and the generated body is derived from the pullback's *forward* type signature

```
T = Tuple{QuantumNLDiffEq.var"#calculate_diff_evalue##0#..."{DQCType}, Float64}
```

`DQCType.afm` is declared `::AbstractFeatureMap`, i.e. abstractly typed, so this `T` is **identical for `Product`, `ChebyshevSparse` and `ChebyshevTower`** — only the captured pullback data differs (`Zygote.ZBack{asin_pullback}` vs `acos_pullback` + `times_pullback2`, i.e. different tuple arities).

The new `@compile_workload` in `src/precompile.jl` called `loss` and `train!` with `ChebyshevSparse`, so that adjoint got compiled and serialized into the package image. At runtime it is then reused for the other feature maps, whose captured-pullback layout does not match — hence the `Nothing` gradient / out-of-range tuple index.

Verified locally on Julia 1.12.4 (repro: build the three `Mapping Tests` circuits and call `train!(...; steps = 1)`):

| workload contents | Product | ChebyshevSparse | ChebyshevTower |
|---|---|---|---|
| no workload (`include("precompile.jl")` commented out) | OK | OK | OK |
| workload, non-AD calls only | OK | OK | OK |
| workload + `loss` (ChebyshevSparse) | OK | OK | OK |
| workload + `loss` (Product) | OK | **FAIL** | **FAIL** |
| workload + `train!` (ChebyshevSparse) — i.e. master | **FAIL** | OK | **FAIL** |
| workload + `train!` (Product) | OK | **FAIL** | **FAIL** |

Flipping the workload's feature map flips which mappings break, which pins the mechanism down: whichever feature map the workload differentiates is the only one that works afterwards. Note the plain `loss` entry point is corrupted too, not just `train!`, so this affects users, not only the test suite.

## Fix

Keep Zygote out of the precompile workload. `src/precompile.jl` now exercises only the forward, non-differentiated path — `phi`, `load`, `new_circuit`, `calculate_evalue` (both `Pinned` and `Floating`) and `ODEEncode` — which is where the Yao circuit-construction/`expect` compile latency actually is. `loss` and `train!` are removed, with a comment explaining why they must not be added back.

The precompile workload was not deleted; it still covers the forward path. The AD calls are the part that is fundamentally unsafe to precompile here, and there is no way to make them safe from this package short of parameterizing `DQCType` on the feature-map type, which would be a breaking change to a public exported type.

Also adds a regression test in `test/precompile_workload.jl` that runs `loss` and one `train!` step for all three built-in feature maps on a small 2-qubit problem, against the precompiled image. Confirmed that this test errors when the `train!` call is put back into the workload and passes with the fix.

## Verification

Locally on Julia 1.12.4 (macOS aarch64):

- `test/precompile_workload.jl` — 7/7 pass (~2.5 min)
- `test/interfaces.jl` — 6/6 pass
- `test/odeencode_rrule.jl` — 4/4 pass
- repro of the two failing `Mapping Tests` circuits via `train!(...; steps = 1)`: all three feature maps OK

The full `Core` suite (`damped_oscillation_tests.jl`, `encoding_multifunction_tests.jl`) trains 6-qubit circuits for hundreds of Adam steps and takes 1.5–3.5 h per lane; it is left to CI. The failure being fixed here is an immediate exception at the first gradient evaluation, so the `steps = 1` repro and the new regression test cover it directly, and the fix restores the workload to a state where it touches no AD code, i.e. the pre-#75 behaviour of the differentiated paths.

No version bump here — a separate release pass handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
