### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/loss.jl
+++ b/src/loss.jl
@@ -100,8 +100,8 @@ function loss_reg(
     for x in 1:length(rp.M_reg)
         evalue = [
             calculate_evalue(
-                    DQC, cost[i], u0[i], abh, theta, rp.M_reg[x], rp.M_reg[1]
-                )
+                DQC, cost[i], u0[i], abh, theta, rp.M_reg[x], rp.M_reg[1]
+            )
                 for i in 1:no_eqns
         ]
         loss_ind = [loss(evalue[i], rp.u_reg[i][x]) for i in 1:no_eqns]
@@ -121,8 +121,8 @@ function loss_reg(
     for x in 1:length(rp.M_reg)
         evalue = [
             calculate_evalue(
-                    DQC[i], cost[i], u0[i], abh, theta[i], rp.M_reg[x], rp.M_reg[1]
-                )
+                DQC[i], cost[i], u0[i], abh, theta[i], rp.M_reg[x], rp.M_reg[1]
+            )
                 for i in 1:no_eqns
         ]
         loss_ind = [loss(evalue[i], rp.u_reg[i][x]) for i in 1:no_eqns]


### PR DESCRIPTION
## What changed and why

Reformats `src/loss.jl` for Runic v1.10's updated formatting rules. This is a mechanical formatting-only change so the repository's Runic check passes with the current release.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

The unmodified base commit `768633b6ebaaa3cb364e7a48610d02b7d052ecf3` exits 1 under Runic v1.10.0. With this change applied:

```text
~/.juliaup/bin/julia +release --project=@runic -m Runic --check .
exit 0

git diff --check
exit 0

typos (changed files)
exit 0

GROUP=QA julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Quality Assurance | 20 passed / 20 total

julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/damped_oscillation_tests.jl | 8 passed / 8 total
Core/encoding_multifunction_tests.jl | 1 passed / 1 total
Core/interfaces.jl | 6 passed / 6 total
Core/odeencode_rrule.jl | 4 passed / 4 total
Core/precompile_workload.jl | 7 passed / 7 total
Testing QuantumNLDiffEq tests passed
```

## Not verified

No GPU-specific or downstream-package jobs were run locally.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
