### PR TITLE
Fix zero_state MethodError on 32-bit Julia

### DIFF
--- a/src/QuantumNLDiffEq.jl
+++ b/src/QuantumNLDiffEq.jl
@@ -121,7 +121,7 @@ map = QuantumNLDiffEq.ChebyshevSparse(2)
 ```
 """
 struct ChebyshevSparse <: AbstractFeatureMap
-    pc::Int64
+    pc::Int
 end
 
 """
@@ -146,7 +146,7 @@ map = QuantumNLDiffEq.ChebyshevTower(2)
 ```
 """
 struct ChebyshevTower <: AbstractFeatureMap
-    pc::Int64
+    pc::Int
 end
 
 """
@@ -344,7 +344,7 @@ Base.@kwdef mutable struct DQCType
     fm::AbstractBlock
     cost::Union{Vector{<:AbstractBlock}, Vector{<:Vector{<:AbstractBlock}}}
     var::AbstractBlock
-    N::Int64
+    N::Int
     evol::Union{TimeEvolution, IdentityGate} = igate(N)
 end
 

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -11,6 +11,8 @@ group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
+# x86 is substantially slower than x64 for this suite (x64 ~3.5h); keep the 6h cap.
+timeout = 360
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- `DQCType.N` and Chebyshev `pc` were `Int64`; Yao's `zero_state` is defined for `Int`.
- On 32-bit Julia (`Int === Int32`) this is a MethodError and fails x86 CI.

## Test plan
- [ ] Existing tests pass on x64
- [ ] x86 Core lane green

Made with [Cursor](https://cursor.com)