### PR TITLE
Release QuantumNLDiffEq 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumNLDiffEq"
 uuid = "5411918f-e61c-4722-a33e-8517a813f4bd"
 authors = ["SciML"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Bumps `QuantumNLDiffEq` 1.2.2 -> 1.2.3 (patch).

Source files changed since 1.2.2:
- `src/QuantumNLDiffEq.jl`

Commits:
- Add 32-bit Core CI lane via test_groups.toml (#82)
- Fix zero_state MethodError on 32-bit Julia (#83)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
